### PR TITLE
Automatically open a browser (OSX & Linux) when running make server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+URL := http://localhost:1313
+OPEN_CMD := $(shell command -v open || command -v xdg-open || echo : 2>/dev/null)
 
 hugo:
 	@echo Downloading hugo wrapper 
@@ -5,6 +7,7 @@ hugo:
 	@@chmod +x hugo
 
 server: hugo
+	(sleep 2; $(OPEN_CMD) $(URL)) &
 	./hugo server -w -s src
 
 static: hugo


### PR DESCRIPTION
This way you avoid the extra need to look up for the URL, type it,
or click it, making our lifes easier.