### PR TITLE
Add link to the documentation to the main menu

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -26,10 +26,15 @@ weight = 1
 languageName = "English"
 
 [[Languages.en.menu.shortcuts]]
+name = "<i class='fas fa-fw fa-book'></i> Documentation"
+url = "https://docs.ovn.org"
+weight = 10
+
+[[Languages.en.menu.shortcuts]]
 name = "<i class='fab fa-fw fa-github'></i> GitHub repo"
 identifier = "ds"
 url = "https://github.com/ovn-org/"
-weight = 10
+weight = 20
 
 # [[Languages.en.menu.shortcuts]]
 # name = "<i class='fas fa-fw fa-envelope'></i> User mailing list"


### PR DESCRIPTION
Add a Documentation link to the main menu so that we have it linked somehow.
It'd be great to investigate how to integrate 'docs.ovn.org' into this layout instead of redirecting to the external site.

Signed-off-by: Daniel Alvarez <dalvarez@redhat.com>