### PR TITLE
Add Release content for OVN

### DIFF
--- a/src/content/releases/_index.en.md
+++ b/src/content/releases/_index.en.md
@@ -5,11 +5,11 @@ pre = "<b>4. </b>"
 weight = 15
 +++
 
+This page contains the latest releases of OVN for each series. To learn
+more about the release scheme for OVN, please see the versioning document
+located [here](https://github.com/ovn-org/ovn/blob/master/Documentation/internals/release-process.rst).
 
-## release 1
-
-## release 2  
-
-...
-
-
+| Series | Release | Release Date |
+| ------ | ------- | ------------ |
+| OVN 20.06 | [OVN 20.06.1](https://github.com/ovn-org/ovn/releases/tag/v20.06.1) | 08 Jul 2020 |
+| OVN 20.03 | [OVN 20.03.1](https://github.com/ovn-org/ovn/releases/tag/v20.03.1) | 11 Jun 2020 |

--- a/src/content/releases/previous_releases.md
+++ b/src/content/releases/previous_releases.md
@@ -1,0 +1,17 @@
++++
+date = 2020-07-09T08:53:23-04:00
+title = "Previous Releases"
++++
+
+The following releases are out of date and should only be used if your
+environment specifically requires them. Please consider using the newest
+release in the series instead.
+
+| Series | Release | Release Date |
+| ------ | ------- | ------------ |
+| OVN 20.06 | [OVN 20.06.0](https://github.com/ovn-org/ovn/releases/tag/v20.06.0) | 09 Jun 2020 |
+| OVN 20.03 | [OVN 20.03.0](https://github.com/ovn-org/ovn/releases/tag/v20.03.0) | 02 Mar 2020 |
+
+Prior to the 20.03 series, OVN was included as part of the Open vSwitch project.
+To get versions prior to 20.03.0, please retrieve them from the Open vSwitch
+[github repository](https://github.com/openvswitch/ovs/releases)


### PR DESCRIPTION
For the time being, this is being presented as static markdown. This at
least gets us an actual "Releases" page, and it isn't too difficult to
amend by hand as we create new releases.

A future improvement would be to generate the releases page with a script
so that updating the releases would be even easier in the future.

Signed-off-by: Mark Michelson <mmichels@redhat.com>