### PR TITLE
dist-docs: Add workflow to automate procedure

### DIFF
--- a/.github/workflows/dist-docs.yml
+++ b/.github/workflows/dist-docs.yml
@@ -1,0 +1,158 @@
+name: Rebuild src/static/support/dist-docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    env:
+      dependencies: |
+        automake libtool gcc bc libjemalloc1 libjemalloc-dev    \
+        libssl-dev llvm-dev libelf-dev libnuma-dev libpcap-dev  \
+        selinux-policy-dev \
+        ghostscript markdown
+      m32_dependecies: gcc-multilib
+      ASAN:        ${{ matrix.asan }}
+      BRANCH:      ${{ matrix.branch }}
+      CC:          gcc
+      LIBS:        ${{ matrix.libs }}
+      M32:         ${{ matrix.m32 }}
+      OPTS:        --disable-ssl
+      TESTSUITE:   ${{ matrix.testsuite }}
+
+    name: linux ${{ join(matrix.*, ' ') }}
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - branch:       master
+          - branch:       branch-21.03
+
+    steps:
+    - name: checkout ovn-website
+      uses: actions/checkout@v2
+      with:
+        path: 'ovn-website'
+        ref: 'master'
+
+    - name: checkout OVN
+      uses: actions/checkout@v2
+      with:
+        repository: 'ovn-org/ovn'
+        path: 'ovn'
+        ref: ${{ matrix.branch }}
+        submodules: recursive
+
+    - name: update APT cache
+      run:  sudo apt update
+
+    - name: install required dependencies
+      run:  sudo apt install -y ${{ env.dependencies }}
+
+    - name: install libunbound libunwind
+      if:   matrix.m32 == ''
+      run:  sudo apt install -y libunbound-dev libunwind-dev
+
+    - name: install 32-bit dependencies
+      if:   matrix.m32 != ''
+      run:  sudo apt install -y ${{ env.m32_dependecies }}
+
+    - name: update PATH
+      run:  |
+        echo "$HOME/bin"        >> $GITHUB_PATH
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: set up python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: prepare ovn
+      run:  |
+        pushd ./ovn
+        ./.ci/linux-prepare.sh
+        popd
+
+    - name: build ovn
+      run:  |
+        pushd ./ovn
+        ./.ci/linux-build.sh
+        popd
+
+    - name: build ovn dist-docs
+      run:  |
+        pushd ./ovn
+        make dist-docs
+        popd
+
+    - name: replace dist-docs content
+      if: ${{ success() }}
+      run:  |
+        pushd ./ovn
+        tar -czvf /tmp/dist-docs.tgz dist-docs
+        popd
+        DOCS_DIR="dist-docs"
+        [ "${BRANCH}" == "master" ] || DOCS_DIR="${DOCS_DIR}-${BRANCH}"
+        pushd ./ovn-website
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        export OVN_WEBSITE_BRANCH="dist-docs-${BRANCH}"
+        git checkout ${OVN_WEBSITE_BRANCH} || git checkout -b ${OVN_WEBSITE_BRANCH}
+        pushd ./src/static/support
+        rm -rf ./${DOCS_DIR}
+        mkdir -v ./${DOCS_DIR}
+        tar xzvf /tmp/dist-docs.tgz --strip-components=1 -C ./${DOCS_DIR}
+        git add ${DOCS_DIR}
+        popd
+        git commit -m "dist-docs: Update OVN $BRANCH manpages"
+        git push --force origin "${OVN_WEBSITE_BRANCH}"
+        popd
+        # Setting these variables for the pull request
+        echo "PULL_REQUEST_FROM_BRANCH=${OVN_WEBSITE_BRANCH}" >> $GITHUB_ENV
+        echo "PULL_REQUEST_TITLE=Pulling dist-docs from OVN ${BRANCH}" >> $GITHUB_ENV
+
+    - name: pull-request for updated dist-docs
+      if: ${{ success() }}
+      id: pull_request
+      uses: vsoch/pull-request-action@1.0.15
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PULL_REQUEST_BRANCH: "master"
+        BRANCH_PREFIX: "dist-docs-"
+        PULL_REQUEST_UPDATE: true
+
+    - name: pull-request info
+      if: ${{ success() }}
+      env:
+        pull_request_number_output: ${{ steps.pull_request.outputs.pull_request_number }}
+        pull_request_url_output: ${{ steps.pull_request.outputs.pull_request_url }}
+      run: |
+        echo "Pull request number: ${pull_request_number_output}"
+        echo "Pull request url: ${pull_request_url_output}"
+
+    - name: copy logs on failure
+      if: failure() || cancelled()
+      run: |
+        pushd ./ovn
+        # upload-artifact@v2 doesn't work well enough with wildcards.
+        # So, we're just archiving everything here to avoid any issues.
+        mkdir logs
+        cp config.log ./logs/
+        tar -czvf logs.tgz logs/
+        popd
+
+    - name: upload logs on failure
+      if: failure() || cancelled()
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs-linux-${{ join(matrix.*, '-') }}
+        path: ovn/logs.tgz
+
+    - name: upload dist-docs on failure
+      if: failure() || cancelled()
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist-docs-${{ join(matrix.*, '-') }}
+        path: /tmp/dist-docs.tgz


### PR DESCRIPTION
This is a github workflow used to automate the steps described
in https://github.com/ovn-org/ovn-website/commit/436763be21f7bd1811e937f665dc356d3729daed

With this change, the workflow is on [manual trigger](https://docs.github.com/en/actions/reference/events-that-trigger-workflows), but we may decide to automate that as well later on.

Once ran, this workflow will generate a pull request for master, as well as
any OVN branch listed under its matrix. Re-running the workflow will update the
PR, so it can be ran multiple times without creating any conflicts. The master
branch's dist docs will be stored under src/static/support/dist-docs .
All non-master OVN branches will be kept as src/static/support/dist-docs-${BRANCH}

Once merged, use the url https://www.ovn.org/support/dist-docs (or
https://www.ovn.org/support/dist-docs-${BRANCH}) in order to get to this content.