### PR TITLE
docs: Add dist-docs for 21.06 to workflow

### DIFF
--- a/.github/workflows/dist-docs.yml
+++ b/.github/workflows/dist-docs.yml
@@ -29,6 +29,7 @@ jobs:
         include:
           - branch:       master
           - branch:       branch-21.03
+          - branch:       branch-21.06
 
     steps:
     - name: checkout ovn-website


### PR DESCRIPTION
After merging, please run workflow manually,
via: https://github.com/ovn-org/ovn-website/actions/workflows/dist-docs.yml

Once this workflow is ran and its generated pr gets merged, we
can follow up and improve the https://www.ovn.org/ page to list
the docs for the various releases.