### PR TITLE
docs: Add dist-docs for 21.09 to workflow

### DIFF
--- a/.github/workflows/dist-docs.yml
+++ b/.github/workflows/dist-docs.yml
@@ -30,6 +30,7 @@ jobs:
           - branch:       main
           - branch:       branch-21.03
           - branch:       branch-21.06
+          - branch:       branch-21.09
 
     steps:
     - name: checkout ovn-website

--- a/src/content/releases/release_21.03.0.md
+++ b/src/content/releases/release_21.03.0.md
@@ -32,3 +32,8 @@ In addition to bug fixes, the 21.03.0 release of OVN contains a mix of new featu
 - Partial set and partial map updates are used in place of full set replacement in OVSDB operations. In several cases this greatly reduces the size of messages transmitted during OVSDB operations.
 - Rather than pre-programming all possible load balancer hairpin flows, we now use the "learn" action in OVS. This has the potential to greatly reduce the number of flows installed by OVN.
 - Several checks of conntrack fields have been removed. This improves chances of flows being offloadable in certain scenarios.
+
+### Documentation
+
+Distribution documentation (aka man pages) specific to this release is
+[available here](https://www.ovn.org/support/dist-docs-branch-21.03/).

--- a/src/content/releases/release_21.06.0.md
+++ b/src/content/releases/release_21.06.0.md
@@ -18,3 +18,7 @@ In addition to bug fixes, the 21.06.0 release of OVN contains a mix of new featu
 - ct.inv can be disabled for deployments where offloading to smart NICs is desired.
 - Similar to the ovn-nbctl daemon, ovn-sbctl has a daemon mode.
 
+### Documentation
+
+Distribution documentation (aka man pages) specific to this release is
+[available here](https://www.ovn.org/support/dist-docs-branch-21.06/).


### PR DESCRIPTION
After merging, please run workflow manually,
via: https://github.com/ovn-org/ovn-website/actions/workflows/dist-docs.yml

Once this workflow is ran and its generated pr gets merged, we
can follow up and improve the https://www.ovn.org/ page to list
the docs for the various releases.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>