### PR TITLE
docs: Add dist-docs for 22.03, 22.06 and 22.09 to workflow

### DIFF
--- a/.github/workflows/dist-docs.yml
+++ b/.github/workflows/dist-docs.yml
@@ -28,9 +28,9 @@ jobs:
       matrix:
         include:
           - branch:       main
-          - branch:       branch-21.03
-          - branch:       branch-21.06
-          - branch:       branch-21.09
+          - branch:       branch-22.03
+          - branch:       branch-22.06
+          - branch:       branch-22.09
 
     steps:
     - name: checkout ovn-website


### PR DESCRIPTION
After merging, please run workflow manually,
via: https://github.com/ovn-org/ovn-website/actions/workflows/dist-docs.yml

Once this workflow is ran and its generated pr gets merged, we can follow up and improve the https://www.ovn.org/ page to list the docs for the various releases.

See comment in commit 8246a6876989e4f2997fa7541dd6430b7f7cfbf7 for more info.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>