### PR TITLE
Add manpages information for releases

### DIFF
--- a/src/content/_index.en.md
+++ b/src/content/_index.en.md
@@ -39,7 +39,7 @@ We have weekly IRC meetings you can participate in:
 IRC meeting every Thu 1715 UTC in **#openvswitch** on [irc.libera.chat](https://libera.chat) 
 
 {{% notice info %}}
-Until recently, OVN code lived within the Open vSwitch codebase. OVN was
-recently [split](https://github.com/openvswitch/ovs/commit/f3e24610ea18eb873dc860f1710432e9aacd27fd)
-into its [own repo](https://github.com/ovn-org/ovn).
+OVN code used to live within the Open vSwitch codebase. It was
+[split](https://github.com/openvswitch/ovs/commit/f3e24610ea18eb873dc860f1710432e9aacd27fd)
+into its [own repo](https://github.com/ovn-org/ovn) in 2019.
 {{% /notice %}}

--- a/src/content/releases/_index.en.md
+++ b/src/content/releases/_index.en.md
@@ -9,23 +9,23 @@ This page lists the current supported OVN release, and previous obsoleted releas
 To learn more about the release scheme for OVN, please see the versioning document
 located [here](https://github.com/ovn-org/ovn/blob/master/Documentation/internals/release-process.rst).
 
-| Series | Release | Release Date | Release Notes |
-| ------ | ------- | ------------ | ------------- |
-| OVN 22.12 | [OVN 22.12.0](https://github.com/ovn-org/ovn/releases/tag/v22.12.0)       | 16 Dec 2022 | [Release 22.12.0](release_22.12.0) |
-| OVN 22.09 | [OVN 22.09.0](https://github.com/ovn-org/ovn/releases/tag/v22.09.0)       | 16 Sep 2022 | [Release 22.09.0](release_22.09.0) |
-| OVN 22.06 | [OVN 22.06.0](https://github.com/ovn-org/ovn/releases/tag/v22.06.0)       | 03 Jun 2022 | [Release 22.06.0](release_22.06.0) |
-| OVN 22.03 | [OVN 22.03.1 (LTS)](https://github.com/ovn-org/ovn/releases/tag/v22.03.1) | 03 Jun 2022 | [Release 22.03.0](release_22.03.0) |
-| OVN 21.12 | [OVN 21.12.2](https://github.com/ovn-org/ovn/releases/tag/v21.12.2)       | 03 Jun 2022 | N/A                                |
-| OVN 21.09 | [OVN 21.09.0](https://github.com/ovn-org/ovn/releases/tag/v21.09.0)       | 04 Oct 2021 | [Release 21.09.0](release_21.09.0) |
-| OVN 21.06 | [OVN 21.06.0](https://github.com/ovn-org/ovn/releases/tag/v21.06.0)       | 18 Jun 2021 | [Release 21.06.0](release_21.06.0) |
-| OVN 21.03 | [OVN 21.03.0](https://github.com/ovn-org/ovn/releases/tag/v21.03.0)       | 12 Mar 2021 | [Release 21.03.0](release_21.03.0) |
-| OVN 20.12 | [OVN 20.12.0](https://github.com/ovn-org/ovn/releases/tag/v20.12.0)       | 18 Dec 2020 | [Release 20.12.0](release_20.12.0) |
-| OVN 20.09 | [OVN 20.09.0](https://github.com/ovn-org/ovn/releases/tag/v20.09.0)       | 29 Sep 2020 | [Release 20.09.0](release_20.09.0) |
-| OVN 20.06 | [OVN 20.06.2](https://github.com/ovn-org/ovn/releases/tag/v20.06.2)       | 21 Aug 2020 |                                    |
-|           | [OVN 20.06.1](https://github.com/ovn-org/ovn/releases/tag/v20.06.1)       | 08 Jul 2020 |                                    |
-|           | [OVN 20.06.0](https://github.com/ovn-org/ovn/releases/tag/v20.06.0)       | 09 Jun 2020 |                                    |
-| OVN 20.03 | [OVN 20.03.1](https://github.com/ovn-org/ovn/releases/tag/v20.03.1)       | 11 Jun 2020 |                                    |
-|           | [OVN 20.03.0](https://github.com/ovn-org/ovn/releases/tag/v20.03.0)       | 02 Mar 2020 |                                    |
+| Series | Release | Release Date | Release Notes | Manpages |
+| ------ | ------- | ------------ | ------------- | --------- |
+| OVN 22.12 | [OVN 22.12.0](https://github.com/ovn-org/ovn/releases/tag/v22.12.0)       | 16 Dec 2022 | [Release 22.12.0](release_22.12.0) | [Doc 22.12.0](https://www.ovn.org/support/dist-docs-branch-22.12/) |
+| OVN 22.09 | [OVN 22.09.0](https://github.com/ovn-org/ovn/releases/tag/v22.09.0)       | 16 Sep 2022 | [Release 22.09.0](release_22.09.0) | [Doc 22.09.0](https://www.ovn.org/support/dist-docs-branch-22.09/) |
+| OVN 22.06 | [OVN 22.06.0](https://github.com/ovn-org/ovn/releases/tag/v22.06.0)       | 03 Jun 2022 | [Release 22.06.0](release_22.06.0) | [Doc 22.06.0](https://www.ovn.org/support/dist-docs-branch-22.06/) |
+| OVN 22.03 | [OVN 22.03.1 (LTS)](https://github.com/ovn-org/ovn/releases/tag/v22.03.1) | 03 Jun 2022 | [Release 22.03.0](release_22.03.0) | [Doc 22.03.0](https://www.ovn.org/support/dist-docs-branch-22.03/) |
+| OVN 21.12 | [OVN 21.12.2](https://github.com/ovn-org/ovn/releases/tag/v21.12.2)       | 03 Jun 2022 | N/A                                | |
+| OVN 21.09 | [OVN 21.09.0](https://github.com/ovn-org/ovn/releases/tag/v21.09.0)       | 04 Oct 2021 | [Release 21.09.0](release_21.09.0) | [Doc 21.09.0](https://www.ovn.org/support/dist-docs-branch-21.09/) |
+| OVN 21.06 | [OVN 21.06.0](https://github.com/ovn-org/ovn/releases/tag/v21.06.0)       | 18 Jun 2021 | [Release 21.06.0](release_21.06.0) | [Doc 21.06.0](https://www.ovn.org/support/dist-docs-branch-21.06/) |
+| OVN 21.03 | [OVN 21.03.0](https://github.com/ovn-org/ovn/releases/tag/v21.03.0)       | 12 Mar 2021 | [Release 21.03.0](release_21.03.0) | [Doc 21.03.0](https://www.ovn.org/support/dist-docs-branch-21.03/) |
+| OVN 20.12 | [OVN 20.12.0](https://github.com/ovn-org/ovn/releases/tag/v20.12.0)       | 18 Dec 2020 | [Release 20.12.0](release_20.12.0) | |
+| OVN 20.09 | [OVN 20.09.0](https://github.com/ovn-org/ovn/releases/tag/v20.09.0)       | 29 Sep 2020 | [Release 20.09.0](release_20.09.0) | |
+| OVN 20.06 | [OVN 20.06.2](https://github.com/ovn-org/ovn/releases/tag/v20.06.2)       | 21 Aug 2020 |                                    | |
+|           | [OVN 20.06.1](https://github.com/ovn-org/ovn/releases/tag/v20.06.1)       | 08 Jul 2020 |                                    | |
+|           | [OVN 20.06.0](https://github.com/ovn-org/ovn/releases/tag/v20.06.0)       | 09 Jun 2020 |                                    | |
+| OVN 20.03 | [OVN 20.03.1](https://github.com/ovn-org/ovn/releases/tag/v20.03.1)       | 11 Jun 2020 |                                    | |
+|           | [OVN 20.03.0](https://github.com/ovn-org/ovn/releases/tag/v20.03.0)       | 02 Mar 2020 |                                    | |
 
 Prior to the 20.03 series, OVN was included as part of the Open vSwitch project.
 To get versions prior to 20.03.0, please retrieve them from the Open vSwitch


### PR DESCRIPTION
Also update the wording on the landing page in regards to OVN being split out of OVS repository. It was not that recent anymore.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>