### PR TITLE
Update meeting time.

### DIFF
--- a/src/content/_index.en.md
+++ b/src/content/_index.en.md
@@ -36,7 +36,9 @@ Distribution documentation (aka man pages) is [available here](https://www.ovn.o
 We have weekly IRC meetings you can participate in:
 
 [OVN weekly](http://eavesdrop.openstack.org/meetings/ovn_community_development_discussion/2021/)
-IRC meeting every Thu 1715 UTC in **#openvswitch** on [irc.libera.chat](https://libera.chat) 
+IRC meeting every Thu 09:15 AM US Pacific
+(e.g., [Los Angeles, California time](https://www.timeanddate.com/worldclock/usa/los-angeles))
+in **#openvswitch** on [irc.libera.chat](https://libera.chat).
 
 {{% notice info %}}
 OVN code used to live within the Open vSwitch codebase. It was


### PR DESCRIPTION
It should match what's reported on Libera.Chat in the #openvswitch channel banner:

"OVN meeting Thurs 9:15 am US Pacific"