### PR TITLE
Update website for lastest 24.03, 23.09, and 22.03 releases.

### DIFF
--- a/src/content/releases/22.03.md
+++ b/src/content/releases/22.03.md
@@ -10,6 +10,23 @@ This version of OVN is currently supported for all bug fixes.
 This version will enter critical fix mode on 11 March, 2024. 
 Support for this version will end on 11 March, 2025. 
 
+### v22.03.6
+v22.03.6 was released on 1 March, 2024.
+
+[Github link](https://github.com/ovn-org/ovn/releases/tag/v22.03.6)
+
+Release Notes:
+```
+OVN v22.03.6 - 01 Mar 2024
+--------------------------
+  - Bug fixes
+  - Add "garp-max-timeout-sec" config option to vswitchd external-ids to
+    cap the time between when ovn-controller sends gARP packets.
+
+
+```
+[Changelog](../changelog_v22.03.6)
+
 ### v22.03.5
 v22.03.5 was released on 1 December, 2023.
 

--- a/src/content/releases/22.12.md
+++ b/src/content/releases/22.12.md
@@ -1,13 +1,14 @@
 +++
 title = "22.12"
-weight = 251731116199.0
+[_build]
+  list = 'never'
+
 +++
 
 ## OVN 22.12 
 
 OVN 22.12 was initially released on 16 December, 2022. 
-This version of OVN is currently supported for all bug fixes. 
-Support for this version will end on 16 December, 2023. 
+This version of OVN is no longer supported. Support ended on 16 December, 2023.
 
 ### v22.12.2
 v22.12.2 was released on 15 September, 2023.

--- a/src/content/releases/23.09.md
+++ b/src/content/releases/23.09.md
@@ -9,6 +9,22 @@ OVN 23.09 was initially released on 15 September, 2023.
 This version of OVN is currently supported for all bug fixes. 
 Support for this version will end on 15 September, 2024. 
 
+### v23.09.2
+v23.09.2 was released on 1 March, 2024.
+
+[Github link](https://github.com/ovn-org/ovn/releases/tag/v23.09.2)
+
+Release Notes:
+```
+OVN v23.09.2 - 01 Mar 2024
+--------------------------
+  - Bug fixes
+  - Enable PMTU discovery on geneve/vxlan tunnels for E/W traffic.
+
+
+```
+[Changelog](../changelog_v23.09.2)
+
 ### v23.09.1
 v23.09.1 was released on 1 December, 2023.
 

--- a/src/content/releases/all_releases.md
+++ b/src/content/releases/all_releases.md
@@ -20,11 +20,6 @@ For more details, see [23.03 ](../23.03)
 
 
 
-### OVN 22.12
-For more details, see [22.12 ](../22.12)
-
-
-
 ### OVN 22.03
 For more details, see [22.03 ](../22.03)
 
@@ -34,6 +29,11 @@ The following OVN release series are no longer supported. This means that they
 will not receive any future bug fixes, including critical or security fixes.
 It is not recommended to use these unless you absolutely must. Use these at
 your own risk.
+
+### OVN 22.12
+For more details, see [22.12 ](../22.12)
+
+
 
 ### OVN 22.09
 For more details, see [22.09 ](../22.09)

--- a/src/content/releases/changelog_v22.03.4.md
+++ b/src/content/releases/changelog_v22.03.4.md
@@ -1,0 +1,15 @@
++++
+title = "Changelog v22.03.4"
+[_build]
+  list = 'never'
++++
+
+### Changes from v22.03.3 to v22.03.4
+
+- [cb34bf2b](https://github.com/ovn-org/ovn/commit/cb34bf2b9529f96c3d6dc3e9afa818101db6f0ec) Set release date for 22.03.4.
+- [7cf3ded6](https://github.com/ovn-org/ovn/commit/7cf3ded60018c483775a3ffd720fce1a7aaef016) ofctrl: Prevent conjunction duplication
+- [3fae6663](https://github.com/ovn-org/ovn/commit/3fae6663d3d99c533e679ea4df4dddebe18dbaa2) ofctrl: Do not try to program long flows
+- [86e16a15](https://github.com/ovn-org/ovn/commit/86e16a150370a3c6324d637ff973f25d27c718a8) checkpatch: Ignore yml files when checking line lengths.
+- [8bda5475](https://github.com/ovn-org/ovn/commit/8bda5475446f9455668c04a1b508f432806b6707) checkpatch.py: Revert previous commit.
+- [e1c515df](https://github.com/ovn-org/ovn/commit/e1c515dfbc757e52fa3dfc2d72c3bea5bd456bef) checkpatch: Ignore yml files when checking line lengths.
+- [4ceaa510](https://github.com/ovn-org/ovn/commit/4ceaa510c9445337368676b4f382006ef6c264ac) Prepare for 22.03.4.

--- a/src/content/releases/changelog_v22.03.5.md
+++ b/src/content/releases/changelog_v22.03.5.md
@@ -1,0 +1,42 @@
++++
+title = "Changelog v22.03.5"
+[_build]
+  list = 'never'
++++
+
+### Changes from v22.03.4 to v22.03.5
+
+- [15144069](https://github.com/ovn-org/ovn/commit/15144069080c5807957ba5bbb4248252eb4e6065) Set release date for 22.03.5.
+- [b04a873a](https://github.com/ovn-org/ovn/commit/b04a873a8fe6677f837cfbd087d31c702aa082ec) pinctrl: reset success and failures n_count regardless of svc state
+- [dd5d976c](https://github.com/ovn-org/ovn/commit/dd5d976c001593c016a28e829ad6f26a4a271589) pinctrl: send RST instead of RST_ACK bit for lb hc
+- [a1723096](https://github.com/ovn-org/ovn/commit/a1723096809445b9ddf16fb4f401f46112e424e4) controller: Don't artificially limit group and meter IDs to 16bit.
+- [3e5f6ac6](https://github.com/ovn-org/ovn/commit/3e5f6ac668bee720e51fbd51bdb16e1997a16222) tests: fixed race_condition with max_prefix
+- [b9a019fd](https://github.com/ovn-org/ovn/commit/b9a019fddd03d87b905e953f577c7421aa223724) tests: fixed "ovn-nbctl - daemon retry connection"
+- [29d16433](https://github.com/ovn-org/ovn/commit/29d16433ef726f9987a911a936435295cdfca71b) tests: fixed system test "LR with SNAT fragmentation needed for external server".
+- [37f19989](https://github.com/ovn-org/ovn/commit/37f199896db8d24d736ffc63d41c7d9a71879f03) ovn-ctl man: Add election timer config to manpage
+- [29124322](https://github.com/ovn-org/ovn/commit/291243221b4d96649f06a596edd89c0a2b5c3afd) controller: have I+P assigning ct_zones for l3gateway ports
+- [5c12a221](https://github.com/ovn-org/ovn/commit/5c12a221e3613c945781f85e27e82e8cce3574b6) tests: fixed another set of flaky ovn-ic tests
+- [fd593b84](https://github.com/ovn-org/ovn/commit/fd593b844c0fc142cbddefceef92804bbbe9658f) tests: do not start backup-northd by default
+- [c43ee0aa](https://github.com/ovn-org/ovn/commit/c43ee0aaab70430d4d15386356a61b8ef8f16cc2) ci: Pin Python, Fedora and Ubuntu runner versions.
+- [579380d2](https://github.com/ovn-org/ovn/commit/579380d2f56b49409b1306df6f20d78665076500) ovs: Bump submodule to include E721 fixes.
+- [ff833995](https://github.com/ovn-org/ovn/commit/ff833995bb7b78284ddecf96c73dfca0a3443071) tests: Remove broken "feature inactivity probe" test.
+- [827ff007](https://github.com/ovn-org/ovn/commit/827ff007a254acb929d06772da42a2bd5c7b2a68) ovs: Bump submodule to use v3.0.5.
+- [62cfae95](https://github.com/ovn-org/ovn/commit/62cfae95d1edee4cbc5b356bac054b3976e465db) py-requirements: Remove hacking dependency and use recent flake8.
+- [0deaaa54](https://github.com/ovn-org/ovn/commit/0deaaa54f068c51b78e021dfbbf7a0ae37773155) controller, northd: Wait for cleanup before replying to exit
+- [e47d7821](https://github.com/ovn-org/ovn/commit/e47d78218339070dbb003dc6e979153370f322ea) tests: Add missing check for scapy.
+- [4e04d4de](https://github.com/ovn-org/ovn/commit/4e04d4de9207db963cfe94b4ea89e25beaa67f9e) system-tests: Make sure that IPv6 address is available right away
+- [674690bb](https://github.com/ovn-org/ovn/commit/674690bb3533534de3ccb83e758202871aeda9d2) northd: Allow need frag to be SNATed
+- [b30f7c94](https://github.com/ovn-org/ovn/commit/b30f7c948c7e3e5e74799d9f17f35ab81dcdb0b1) memory-trim: Fix timestamp overflow warning right after reboot.
+- [33e8ade3](https://github.com/ovn-org/ovn/commit/33e8ade327e2a196f89f6b9ba3cf8a286d5ea2de) tests: fixed "send gratuitous ARP for NAT rules on HA distributed router"
+- [6c180197](https://github.com/ovn-org/ovn/commit/6c18019749cee68a512c716df478e404f25f21e0) tests: move trim_zeros() to ovn-macros
+- [6b4e6669](https://github.com/ovn-org/ovn/commit/6b4e666905315113b8d4d977a5f78590a3a0fa50) tests: fixed "L2 Drop and Allow ACL w/ Stateful ACL"
+- [046895e5](https://github.com/ovn-org/ovn/commit/046895e5aaf579b88aaece1940d4b430ea34f16d) tests: fixed multiple tests missing ovn-nbctl "wait"
+- [ded718f7](https://github.com/ovn-org/ovn/commit/ded718f706fc2668c1267d11e70af41a5068d23d) tests: fixed "Logical router policy packet marking"
+- [ed2ca4a8](https://github.com/ovn-org/ovn/commit/ed2ca4a802c53a098baabed0198bf53577093efb) tests: fixed multiple ovn-ic tests
+- [96f70d46](https://github.com/ovn-org/ovn/commit/96f70d46f2b47f2c3119f33fe73316e0164d4016) pinctrl: Reply with correct destination for ICMPv6 RA packets
+- [bc8276be](https://github.com/ovn-org/ovn/commit/bc8276be3251e0f98510b06600767c4bbf9cb9f7) ovn-controller: Add monitor condition for FDB.
+- [792742ef](https://github.com/ovn-org/ovn/commit/792742efb36cb64013519d7f13dc95da53697aa3) northd: Drop packets destined to router owned NAT IP for DGP.
+- [74de34d9](https://github.com/ovn-org/ovn/commit/74de34d9062d8d1cd5600b8f2ae1abde73955968) Rename scapy-server into scapy-server.py
+- [a6415493](https://github.com/ovn-org/ovn/commit/a64154932fe70d878250e7f13a4c176715de7fa2) Add ovnkube-identity binary to the ovn-kubernetes Dockerfile
+- [e19dc335](https://github.com/ovn-org/ovn/commit/e19dc3352b73b513201543afb7dc5553d8ab47ce) tests: offload scapy transformations to a separate unixctl daemon
+- [dce2409f](https://github.com/ovn-org/ovn/commit/dce2409f1161a4cd6ecd8829a7c31b3d42b53526) Prepare for 22.03.5.

--- a/src/content/releases/changelog_v22.03.6.md
+++ b/src/content/releases/changelog_v22.03.6.md
@@ -1,0 +1,31 @@
++++
+title = "Changelog v22.03.6"
+[_build]
+  list = 'never'
++++
+
+### Changes from v22.03.5 to v22.03.6
+
+- [f894e167](https://github.com/ovn-org/ovn/commit/f894e167aa1e7957694ec1d161f209ec0bf07879) Set release date for 22.03.6.
+- [0ac5e327](https://github.com/ovn-org/ovn/commit/0ac5e327dff127b718eab47c65ee837a5236437a) pinctrl: dns: Ignore additional records.
+- [7f63921c](https://github.com/ovn-org/ovn/commit/7f63921cec6720857938aee3583513b03845864d) ovn-ic: Fix global blacklist filter for IPv6 addresses.
+- [dd6d78d4](https://github.com/ovn-org/ovn/commit/dd6d78d4a2143ecce186feb92a87fd4eff901079) Documentation: Fix broken links in ovn-sandbox.rst.
+- [e2117a8d](https://github.com/ovn-org/ovn/commit/e2117a8d4b460667cdfadf2c933f653a5c535474) github: Update versions of action dependencies (Node.js 20).
+- [aff94da5](https://github.com/ovn-org/ovn/commit/aff94da55f6f5804216c0979b6ac1f8e2bd40cd3) actions: Use random port selection for SNAT with external_port_range.
+- [8396f007](https://github.com/ovn-org/ovn/commit/8396f00743cb00d3229edbff8104d8da73f81557) ovn-ic: Handle NB:name updates properly.
+- [47d61c5e](https://github.com/ovn-org/ovn/commit/47d61c5e7bee9f7e295dc175ef9ab25d1f65745f) controller: fixed potential segfault when changing tunnel_key and deleting ls.
+- [26242f10](https://github.com/ovn-org/ovn/commit/26242f10a355edaf2a047710fde672e3cc2d8ed7) northd: Use proper field for lookup_nd
+- [3772a121](https://github.com/ovn-org/ovn/commit/3772a1211ab8e8737f0420191550d5b632be08e3) test: add dedicated test for garp-max-timeout
+- [1912442b](https://github.com/ovn-org/ovn/commit/1912442ba4adf9719ed10f9e54f4455e9cd20426) treewide: Fix small memory leaks reported by static analysis
+- [03b622f7](https://github.com/ovn-org/ovn/commit/03b622f747ac891d02eae3c7efefe9ad340f540e) ovs: Bump submodule to include IDL "spurious delete" fix.
+- [8d4c56e3](https://github.com/ovn-org/ovn/commit/8d4c56e33bf43cbc8fd14bff5d7c596d28a74f78) Correct ethtype referencing incorrect values
+- [06639f10](https://github.com/ovn-org/ovn/commit/06639f108a57a47d522167a5dcfbf3347db5f07c) northd: forward arp request to lrp snat on.
+- [3728fbf7](https://github.com/ovn-org/ovn/commit/3728fbf708ab4a743f4c7117865d7d1cee9dcaef) controller: make garp_max_timeout configurable
+- [8548abb3](https://github.com/ovn-org/ovn/commit/8548abb345f13c88b7541d232f5c6a9dfed40353) system-tests: Consolidate wait condition in CoPP test
+- [72b82f87](https://github.com/ovn-org/ovn/commit/72b82f875a8f356fe0e73b8515f4b762c49113e6) pinctrl: Fix up comments about sending RST packets for healthcheck.
+- [037b1dcc](https://github.com/ovn-org/ovn/commit/037b1dcc3708c207c46dbb7b0878130d28c02095) fmt_pkt: make sure scapy-server is started once
+- [e6f1df67](https://github.com/ovn-org/ovn/commit/e6f1df67883e319325666c1953feeb28730e58c8) fmt_pkt: improve scapy-server logging
+- [0eaacaac](https://github.com/ovn-org/ovn/commit/0eaacaac8e135e10dd92a35d83088b599a5e1879) fmt_pkt: use -S check to wait for scapy sock file
+- [97bf3ca9](https://github.com/ovn-org/ovn/commit/97bf3ca92093ec0e47a79b3f9cb632e2f11e3784) fmt_pkt: don't subshell when calling ovs-appctl
+- [91d7cb79](https://github.com/ovn-org/ovn/commit/91d7cb7978b50ad0876961414d8884f1ca39c9b7) controller: fix group_table and meter_table allocation
+- [3fb30fb8](https://github.com/ovn-org/ovn/commit/3fb30fb892855beffdbaf3338c36138cff0eec30) Prepare for 22.03.6.

--- a/src/content/releases/changelog_v22.12.2.md
+++ b/src/content/releases/changelog_v22.12.2.md
@@ -1,0 +1,17 @@
++++
+title = "Changelog v22.12.2"
+[_build]
+  list = 'never'
++++
+
+### Changes from v22.12.1 to v22.12.2
+
+- [daa3d8b9](https://github.com/ovn-org/ovn/commit/daa3d8b9d8225f1fdccc0297dce38ca8428f813b) Set release date for 22.12.2.
+- [9045a780](https://github.com/ovn-org/ovn/commit/9045a7803c0bf47ac746c648498052456aa0b6f7) northd: check if parent_name is set for tag_request 0
+- [6d5700d6](https://github.com/ovn-org/ovn/commit/6d5700d616107e617c40eb741df8bfa132b1cc4c) ofctrl: Prevent conjunction duplication
+- [6b8d94b4](https://github.com/ovn-org/ovn/commit/6b8d94b4377f52d651b9b9a610451a505c7ae161) ofctrl: Do not try to program long flows
+- [8ef0ee43](https://github.com/ovn-org/ovn/commit/8ef0ee43dc2af24dc419ce61b74bd65badf9e205) northd: Always ct commit ECMP symmetric traffic in the original direction.
+- [427d60b7](https://github.com/ovn-org/ovn/commit/427d60b7946bea094427ad467cc6d901598a581c) Use correct nw_ttl=255 to match against legit NAs
+- [8f06142d](https://github.com/ovn-org/ovn/commit/8f06142d6030b8791b1fc7310225669dcff55f9b) checkpatch: Ignore yml files when checking line lengths.
+- [133761a5](https://github.com/ovn-org/ovn/commit/133761a5dbd6f0413cf27853df07190642d2ea39) northd: Make sure that skip_snat=true is evaluated before force_snat
+- [08047a59](https://github.com/ovn-org/ovn/commit/08047a59f8a6d04f3d4741a9fdafd535358c5395) Prepare for 22.12.2.

--- a/src/content/releases/changelog_v23.03.2.md
+++ b/src/content/releases/changelog_v23.03.2.md
@@ -1,0 +1,17 @@
++++
+title = "Changelog v23.03.2"
+[_build]
+  list = 'never'
++++
+
+### Changes from v23.03.1 to v23.03.2
+
+- [05d20a51](https://github.com/ovn-org/ovn/commit/05d20a51032d65b6eed0c499cbb56ddbde5c754d) Set release date for 23.03.2.
+- [22556693](https://github.com/ovn-org/ovn/commit/22556693895e75bef262dbba48f5a5342be41822) northd: check if parent_name is set for tag_request 0
+- [02d2cf03](https://github.com/ovn-org/ovn/commit/02d2cf035e278c873bb1c54bf22a08c15a68f566) ofctrl: Prevent conjunction duplication
+- [a480ed99](https://github.com/ovn-org/ovn/commit/a480ed99dba6a9ab533a466d5755426f128639ed) ofctrl: Do not try to program long flows
+- [724cac38](https://github.com/ovn-org/ovn/commit/724cac380ad21e6d58461ad6a656fa17985ceebf) northd: Always ct commit ECMP symmetric traffic in the original direction.
+- [9dc56cf4](https://github.com/ovn-org/ovn/commit/9dc56cf445e8e7d0518fd71f4bcfd99add8bb536) Use correct nw_ttl=255 to match against legit NAs
+- [681bc898](https://github.com/ovn-org/ovn/commit/681bc898d79b1c713f547e92176be0b87ac0f63b) checkpatch: Ignore yml files when checking line lengths.
+- [ec2acfd4](https://github.com/ovn-org/ovn/commit/ec2acfd4ace75158770f2d417e125acd333ecb4e) northd: Make sure that skip_snat=true is evaluated before force_snat
+- [bed973da](https://github.com/ovn-org/ovn/commit/bed973da0d44a6228598e173e8760000e437eebd) Prepare for 23.03.2.

--- a/src/content/releases/changelog_v23.06.2.md
+++ b/src/content/releases/changelog_v23.06.2.md
@@ -1,0 +1,17 @@
++++
+title = "Changelog v23.06.2"
+[_build]
+  list = 'never'
++++
+
+### Changes from v23.06.1 to v23.06.2
+
+- [4a72621e](https://github.com/ovn-org/ovn/commit/4a72621eca026705b0c185ed2c2938a98e8b57d3) Set release date for 23.06.2.
+- [c869db90](https://github.com/ovn-org/ovn/commit/c869db90e2b18515caad8ad95555d989d3379e3f) northd: check if parent_name is set for tag_request 0
+- [4281178a](https://github.com/ovn-org/ovn/commit/4281178a8882d0194ce8edf35018227ab20fa80e) ofctrl: Prevent conjunction duplication
+- [f18bbbbc](https://github.com/ovn-org/ovn/commit/f18bbbbc1ec0110cde8146ea4e2b34b1ec488ba7) ofctrl: Do not try to program long flows
+- [6de90ba4](https://github.com/ovn-org/ovn/commit/6de90ba4c43e1798a63167fd7f790126cf240e9c) northd: Always ct commit ECMP symmetric traffic in the original direction.
+- [059d1337](https://github.com/ovn-org/ovn/commit/059d1337af1be97b8f89fcf65e2ba6c9ae217d76) Use correct nw_ttl=255 to match against legit NAs
+- [18b9ca06](https://github.com/ovn-org/ovn/commit/18b9ca0630c537b142d6ac849a6a2092d4f5bc0f) checkpatch: Ignore yml files when checking line lengths.
+- [04cf3fd8](https://github.com/ovn-org/ovn/commit/04cf3fd8c2de752ac6ca538f6570547a69dcaac3) northd: Make sure that skip_snat=true is evaluated before force_snat
+- [c215b523](https://github.com/ovn-org/ovn/commit/c215b5237d46e7aa3b7e095f1e955db5b646e4eb) Prepare for 23.06.2.

--- a/src/content/releases/changelog_v23.09.1.md
+++ b/src/content/releases/changelog_v23.09.1.md
@@ -1,0 +1,79 @@
++++
+title = "Changelog v23.09.1"
+[_build]
+  list = 'never'
++++
+
+### Changes from v23.09.0 to v23.09.1
+
+- [0afd4e59](https://github.com/ovn-org/ovn/commit/0afd4e59e95b5f8c7b56760e91269786b0e0e52a) Set release date for 23.09.1.
+- [7fd87c5d](https://github.com/ovn-org/ovn/commit/7fd87c5d0b1492c14d90faec4af4069496ae3609) northd: Add missing stopwatch initialization.
+- [b2f83984](https://github.com/ovn-org/ovn/commit/b2f839849c36c058f940c417dc29e26165a1d30e) controller: avoid extra flows if localnet_learn_fdb is disabled
+- [33b01175](https://github.com/ovn-org/ovn/commit/33b0117598b23b8c0877e482ee350283a147bb5f) controller: FDB entries for localnet should not overwrite entries for vifs
+- [bbd07439](https://github.com/ovn-org/ovn/commit/bbd07439b9a8cd6db901bffcac7ac17f58e33a07) controller: Disable inactivity probe for statctrl
+- [617b84d7](https://github.com/ovn-org/ovn/commit/617b84d7dd2ce3501b49e988e1ba06e86889c9bd) pinctrl: reset success and failures n_count regardless of svc state
+- [beb26027](https://github.com/ovn-org/ovn/commit/beb26027cf26271c7cd780869b540737c7916e99) pinctrl: send RST instead of RST_ACK bit for lb hc
+- [e9e716ad](https://github.com/ovn-org/ovn/commit/e9e716ad531e34766d2f02783ac08955096bf636) controller: Don't artificially limit group and meter IDs to 16bit.
+- [d257d800](https://github.com/ovn-org/ovn/commit/d257d800e41388bd2a387e0b6d5a0e41c2e8d8f1) tests: fixed race_condition with max_prefix
+- [dab54b81](https://github.com/ovn-org/ovn/commit/dab54b81c7ee767943163f2aaaa27b2c4b367964) tests: have CHECK_NO_CHANGE_AFTER_RECOMPUTE potentially wait for ports up
+- [d2e0acb2](https://github.com/ovn-org/ovn/commit/d2e0acb2a6aa510282da5e04036ec5258454c351) tests: fixed "ovn-nbctl - daemon retry connection"
+- [0bb6ba90](https://github.com/ovn-org/ovn/commit/0bb6ba908421825428ec904d5316ae13090adbbf) tests: fixed system test "LR with SNAT fragmentation needed for external server".
+- [810d83e7](https://github.com/ovn-org/ovn/commit/810d83e77ce3398bc94469404d85a01eb63e40bd) tests: fixed "interconnection - static multicast" and "- IGMP/MLD multicast"
+- [25d4b685](https://github.com/ovn-org/ovn/commit/25d4b6855f6ce3795314e9439716f775994c7f4d) ovn-ctl man: Add election timer config to manpage
+- [5375cdd9](https://github.com/ovn-org/ovn/commit/5375cdd96eaf8e527e5afea402f279990398710c) Fix flows not removed in ha migration
+- [619abe5c](https://github.com/ovn-org/ovn/commit/619abe5c5e18f417fe20b252ca41b70e644466e0) binding: handle pb->chassis and pb->up from if-status module
+- [d039b433](https://github.com/ovn-org/ovn/commit/d039b4332b9ea739bdf6b2efc9f5f3e422fe9a42) binding: slight refactor if no local binding in consider_iface_release
+- [f5d01be7](https://github.com/ovn-org/ovn/commit/f5d01be7f1337bdc7885dd45592aa3b376467790) controller: have I+P assigning ct_zones for l3gateway ports
+- [650bffdb](https://github.com/ovn-org/ovn/commit/650bffdbe0562dc364faaef51f51f99e82cccc56) tests: fixed another set of flaky ovn-ic tests
+- [b3d03b94](https://github.com/ovn-org/ovn/commit/b3d03b94178bee2479d6f66ffa34255a7feb79eb) tests: wait for all flows to be installed before sending packets
+- [ac3ece28](https://github.com/ovn-org/ovn/commit/ac3ece28ca04cb74b21c80e2bd73767e29cca9a3) tests: fixed "ipsec -- basic configuration"
+- [fcbc0ae1](https://github.com/ovn-org/ovn/commit/fcbc0ae1c66e31c38ad9d5e099237e7446958035) tests: fixed "LSP incremental processing"
+- [54fae8cb](https://github.com/ovn-org/ovn/commit/54fae8cbb5db827da95a2a52ff28f29e6c7740fe) tests: do not start backup-northd by default
+- [a1422144](https://github.com/ovn-org/ovn/commit/a1422144228bb9924dbc75782734a09c6ecfa534) tests: fixed multiple tests not properly waiting for packets to be received
+- [627955eb](https://github.com/ovn-org/ovn/commit/627955eb79c2cd374853319c1d271c2fd1aeac37) ci: Pin Python, Fedora and Ubuntu runner versions.
+- [1fa7628d](https://github.com/ovn-org/ovn/commit/1fa7628db4155d3a39d55fe61d8d19fa7d3030af) ovs: Bump submodule to include E721 fixes.
+- [5044376d](https://github.com/ovn-org/ovn/commit/5044376da0a1c14d1ccc4b41dfdbae14e74746b2) tests: Remove broken "feature inactivity probe" test.
+- [84c93511](https://github.com/ovn-org/ovn/commit/84c93511ce9a612b9a815cc1403b4841cc2e4c58) readthedocs: Add the configuration file.
+- [39236dc3](https://github.com/ovn-org/ovn/commit/39236dc3151baa3ace58c3ecd62ba0384b4c7a05) Documentation: Use theme from Read The Docs.
+- [74172ed4](https://github.com/ovn-org/ovn/commit/74172ed481f7c239d9258845eb493f17d731df99) ovs: Bump submodule to v3.2.1.
+- [c6a631f0](https://github.com/ovn-org/ovn/commit/c6a631f066eea105c57c265dc68257d1b5ee18e4) py-requirements: Remove hacking dependency and use recent flake8.
+- [be4364e6](https://github.com/ovn-org/ovn/commit/be4364e62ac739744c1ef5bdd74a85fe39d6e37d) ovn-ic: wakeup on ovsdb transaction failures
+- [5f84ff65](https://github.com/ovn-org/ovn/commit/5f84ff658bfd1c26bd9749c3d2e09a7e3567a8bd) ovn-ic: fix potential segmentation violation when ts is deleted
+- [aae5b2ec](https://github.com/ovn-org/ovn/commit/aae5b2ec8ec9f4f9f7c9738d23818c2c4967627c) controller, northd: Wait for cleanup before replying to exit
+- [ea9310a5](https://github.com/ovn-org/ovn/commit/ea9310a5f1e37b373abffd85f7a8dd4fefc30c4e) tests: Add missing check for scapy.
+- [15bf24b8](https://github.com/ovn-org/ovn/commit/15bf24b889b178d4cdbb6166d3bc5434ec59f9fc) ci: Apply the ASAN workaround only for Clang <16
+- [2efc23f3](https://github.com/ovn-org/ovn/commit/2efc23f3edf0293ec81a167e1c4bf99fe5601ca2) ci: Use proper uname argument to get the HW type
+- [349266aa](https://github.com/ovn-org/ovn/commit/349266aac20f229b10ef0313c9f4e6b5f1af4ede) tests: Wait for new ovn-controllers to connect to Southbound.
+- [df7656fb](https://github.com/ovn-org/ovn/commit/df7656fbf6a4ec1175b8f464a1aa6ed6e74fde29) northd: Reset ls_datapath_group if not all chassis support it.
+- [276b9d47](https://github.com/ovn-org/ovn/commit/276b9d47183ebd31c382742025e562fda8d14d11) northd: introduce ls_datapath_group column in lb sb db table
+- [c33398e3](https://github.com/ovn-org/ovn/commit/c33398e32b2753dd6c0cecf35ba48ad8faa69bfc) northd: sync lb applied to logical routers in sb db lb table
+- [e8c79cec](https://github.com/ovn-org/ovn/commit/e8c79cecef9d6e15673be1a604baaaca083f0016) northd: Avoid snat on reply packets for dgw
+- [a9788ef3](https://github.com/ovn-org/ovn/commit/a9788ef39e003b04ec426761833d85bbec1f3b84) northd: Incrementally process SB.Load_balancer updates.
+- [cadfefdf](https://github.com/ovn-org/ovn/commit/cadfefdf1c6457d25b6d1f93e217493739418365) tests: Add missing --wait=sb to the LB I-P test.
+- [dc9eb3a1](https://github.com/ovn-org/ovn/commit/dc9eb3a1cc95accc37165902006db6eeab25fba6) system-tests: Make sure that IPv6 address is available right away
+- [44ee1a6c](https://github.com/ovn-org/ovn/commit/44ee1a6cb40395617f5dbab5829c9f436c16a783) Don't mention packet cloning when failing to find tunnel
+- [94c8f952](https://github.com/ovn-org/ovn/commit/94c8f952bb848806e04a857a84718d2744cfcb9f) northd: Allow need frag to be SNATed
+- [16bdac79](https://github.com/ovn-org/ovn/commit/16bdac7965ae805040a107fc3cdade5bf4db63a2) docs: require ovn-set-local-ip for co-located ovn-controllers
+- [32ab7d94](https://github.com/ovn-org/ovn/commit/32ab7d94f9258ad6e938c715380a567b4a363a62) memory-trim: Fix timestamp overflow warning right after reboot.
+- [bb8fe6ad](https://github.com/ovn-org/ovn/commit/bb8fe6add97ab5fed5e4618b32c16e174faf44c8) Fix missing flows in ls_in_dhcp_options table
+- [bd32a664](https://github.com/ovn-org/ovn/commit/bd32a6646d21c766497494c7a1a4add05a40cd22) controller: throttle port claim attempts from if-status
+- [d30fe25c](https://github.com/ovn-org/ovn/commit/d30fe25c45620017ceea4f06e6e3ebd316ba734f) ci: Free up additional space for ovn-k jobs.
+- [42e81bdc](https://github.com/ovn-org/ovn/commit/42e81bdcebc8cd744deb8034d2fb89ec3b85bf4a) ci: Handle google-cloud-sdk -> google-cloud-cli package name change.
+- [cf99264e](https://github.com/ovn-org/ovn/commit/cf99264e252c20edf93ab5735e18aa3225c98398) ci: Free up disk space in a more robust way.
+- [fd79876c](https://github.com/ovn-org/ovn/commit/fd79876c2757f9074d38bd41cc36f59f3ba26138) ci: Update apt cache before installing gcc-multilib.
+- [94b671cf](https://github.com/ovn-org/ovn/commit/94b671cf89b27f54d1d03149de900994c79df415) tests: fixed "send gratuitous ARP for NAT rules on HA distributed router"
+- [56b0435d](https://github.com/ovn-org/ovn/commit/56b0435d8431518f4299c622a6ec9fc8770b8b0c) tests: move trim_zeros() to ovn-macros
+- [14843108](https://github.com/ovn-org/ovn/commit/148431080738bdec5e625a9ce8d470e365ee14f2) tests: skip test "MAC binding aging" if scapy not available.
+- [6f8719c6](https://github.com/ovn-org/ovn/commit/6f8719c60b8a578d564d3a6147f963fddeeacaa1) tests: fixed "L2 Drop and Allow ACL w/ Stateful ACL"
+- [f8cdfeda](https://github.com/ovn-org/ovn/commit/f8cdfedacf212d9f103c2adba0c6805c01c68ff4) tests: fixed multiple tests missing ovn-nbctl "wait"
+- [cd74dda2](https://github.com/ovn-org/ovn/commit/cd74dda22b255890a120988e8737c22a25c49957) tests: fixed "options:requested-chassis for logical port"
+- [e5a794dc](https://github.com/ovn-org/ovn/commit/e5a794dc30b087e0c78764326c86a3258f97bcc0) tests: fixed "Logical router policy packet marking"
+- [0575b97d](https://github.com/ovn-org/ovn/commit/0575b97dc676d8c225bc8f63befec1bf1390ebe1) tests: fixed multiple ovn-ic tests
+- [b93f36a2](https://github.com/ovn-org/ovn/commit/b93f36a248f7df3eb71b5141c5deadec7c18ee24) pinctrl: Reply with correct destination for ICMPv6 RA packets
+- [c4008ae5](https://github.com/ovn-org/ovn/commit/c4008ae520af2561cfd68749227a8a468277e2e5) ovn-controller: Add monitor condition for FDB.
+- [d16ec6f9](https://github.com/ovn-org/ovn/commit/d16ec6f9a063a0cb2d7bac56e23dd60d0c856b76) Rename scapy-server into scapy-server.py
+- [35d9e42b](https://github.com/ovn-org/ovn/commit/35d9e42bc3e60629701743ca7e9d6890511cf0f5) Add ovnkube-identity binary to the ovn-kubernetes Dockerfile
+- [4a82a493](https://github.com/ovn-org/ovn/commit/4a82a49363a591d429d86d60f9120166ea04cb91) tests: offload scapy transformations to a separate unixctl daemon
+- [0b45a1a1](https://github.com/ovn-org/ovn/commit/0b45a1a1cc6f081184d599ba139847ff03d90912) northd: Remove hosting-chassis only if it's specified
+- [9c56ac4b](https://github.com/ovn-org/ovn/commit/9c56ac4b74f6b964f102b94404b350417b1cd772) QoS: Properly set qos when ovs db is read only
+- [36f37341](https://github.com/ovn-org/ovn/commit/36f37341d32589dcd8d4bfeb023046b07dea1a44) Prepare for 23.09.1.

--- a/src/content/releases/changelog_v23.09.2.md
+++ b/src/content/releases/changelog_v23.09.2.md
@@ -1,0 +1,66 @@
++++
+title = "Changelog v23.09.2"
+[_build]
+  list = 'never'
++++
+
+### Changes from v23.09.1 to v23.09.2
+
+- [04b23938](https://github.com/ovn-org/ovn/commit/04b23938302ad54f453f622a4b0c2fa5e27d3e41) Set release date for 23.09.2.
+- [215d53ea](https://github.com/ovn-org/ovn/commit/215d53ea1436f03ab26a1a65df0824b319e6a4c3) northd: Don't create fair Sb meters for ACLs with logging disabled.
+- [5bf1773c](https://github.com/ovn-org/ovn/commit/5bf1773c90ef7b61a85946027a987184e8d74fa0) ci: Update crun in GitHub actions runner.
+- [afa3da76](https://github.com/ovn-org/ovn/commit/afa3da7677ed4d484612b820d8f09642d5821bd4) ci: Update crun in Cirrus CI cloud image.
+- [683fb6dd](https://github.com/ovn-org/ovn/commit/683fb6dd2fc3c2ab025b1dd87ba2883e40d6d775) controller: ofctrl: Use index for meter lookups.
+- [c463d1de](https://github.com/ovn-org/ovn/commit/c463d1de1a0c2cd368a4809f0d9eda9792b79851) tests: Fix "router port type update and then ...".
+- [cbd4f2fc](https://github.com/ovn-org/ovn/commit/cbd4f2fcd0223a96c739dd07eded753f8f9b2a30) tests: Fix "ovn-controller - Chassis other_config".
+- [81486b62](https://github.com/ovn-org/ovn/commit/81486b62bcac0d081ca907533ae34d826605b485) tests: Fix "ofctrl wait before clearing flows".
+- [48a08a44](https://github.com/ovn-org/ovn/commit/48a08a447340b095e8472d40aaaac5156320b4c1) tests: Fix flaky "ovn-controller-vtep - binding 1".
+- [a088df5a](https://github.com/ovn-org/ovn/commit/a088df5aa75a7207ccdd751d2167e1536113737f) tests: Fix flaky "options:requested-chassis ...".
+- [0a572665](https://github.com/ovn-org/ovn/commit/0a5726652b202add51d1dc8b6557268673e6cc51) tests: Fix typos in tests.
+- [609a943e](https://github.com/ovn-org/ovn/commit/609a943e33c734d368f2019e7d3b41e31bb31d6f) tests: Have tests fail when adding veth peer fails.
+- [511f5a21](https://github.com/ovn-org/ovn/commit/511f5a214226be84ae3b9434ffcab973e37295eb) pinctrl: dns: Ignore additional records.
+- [27d23712](https://github.com/ovn-org/ovn/commit/27d23712260b9faba23018ce973010743e30ccf7) ovn-ic: Fix global blacklist filter for IPv6 addresses.
+- [28b0eddf](https://github.com/ovn-org/ovn/commit/28b0eddff68c5a64b80071a9a27cb79e3fac792a) tests: Fix macro OVN_CHECK_PACKETS_CONTAIN.
+- [c0c9e507](https://github.com/ovn-org/ovn/commit/c0c9e507470439c3220b99c361f71e0cff3406fc) features.c: Always wait on the rconn.
+- [41e7f018](https://github.com/ovn-org/ovn/commit/41e7f01872dae61b9ffcc1d3871865313ff90619) ci: Bump CirrusCI Ubuntu image version
+- [99d22a17](https://github.com/ovn-org/ovn/commit/99d22a176f45971516803129f08c7a37a50bc4a1) Documentation: Fix broken links in ovn-sandbox.rst.
+- [97fca0f8](https://github.com/ovn-org/ovn/commit/97fca0f846bf6839144fc04fed6f0873198b4f89) ovn-sb.xml: Remove IPv4-only restriction from Service Monitors.
+- [2981936b](https://github.com/ovn-org/ovn/commit/2981936b61e0e0694c16df979b986dd1cb60b147) github: Update versions of action dependencies (Node.js 20).
+- [a36f2955](https://github.com/ovn-org/ovn/commit/a36f2955be67a6581e81fb3ae27de825e0046b52) northd: Remove the protocol match from ECMP symmetric reply flows.
+- [6a4c412f](https://github.com/ovn-org/ovn/commit/6a4c412f43d5f1c076fac3784a4ffeb8a3861436) northd: Explicitly handle SNAT for ICMP need frag.
+- [06984247](https://github.com/ovn-org/ovn/commit/069842478601c0b01b0cc3117637e5a00344fcb6) actions: Adjust the ct_commit_nat action.
+- [f224c6e5](https://github.com/ovn-org/ovn/commit/f224c6e5f69c099ddb008f99dba2e19a902a612f) ovs: Bump submodule to tip of OVS branch-3.2.
+- [7ee483a4](https://github.com/ovn-org/ovn/commit/7ee483a45df19e11e26487e64a93940e0de64b9a) actions: Use random port selection for SNAT with external_port_range.
+- [0e684ec2](https://github.com/ovn-org/ovn/commit/0e684ec206e8979694912ad1037145ccd0d0b7dc) ovn-ic: Handle NB:name updates properly.
+- [859e8d91](https://github.com/ovn-org/ovn/commit/859e8d917408d50272c910f78ac44ab8a593aa13) northd: Make sure that affinity flows match on VIP.
+- [d39e7c00](https://github.com/ovn-org/ovn/commit/d39e7c0068ecc719a3d6154e2078d6d9a3435fc9) Fix segfault due to ssl-ciphers.
+- [6d2f9d60](https://github.com/ovn-org/ovn/commit/6d2f9d60760a793c15ca7423b24ff586b653fc76) ovn: Add tunnel PMTUD support.
+- [12007535](https://github.com/ovn-org/ovn/commit/120075357a624293d52a1905c47a1bd249d2157c) controller: fixed potential segfault when changing tunnel_key and deleting ls.
+- [8e25c1c3](https://github.com/ovn-org/ovn/commit/8e25c1c37aa3301f69bc89ee49ffaef5aa2f76fd) northd: Use proper field for lookup_nd
+- [bf334c65](https://github.com/ovn-org/ovn/commit/bf334c65e1ead50013880049564d445919aee61f) checkpatch.py: Port checkpatch related changes from the OVS repo.
+- [6ce267af](https://github.com/ovn-org/ovn/commit/6ce267af7124a93306d8b5bf4944379536ecd264) actions: Make sure affinity learnt flows are auto deleted.
+- [f85f5e39](https://github.com/ovn-org/ovn/commit/f85f5e3929c916985c7dfc0fe0f0433347d8bfae) pinctrl: Directly retrieve desired port_binding MAC.
+- [28fef02d](https://github.com/ovn-org/ovn/commit/28fef02db946ba8113a2752e1abf61d8df5797e3) test: add dedicated test for garp-max-timeout
+- [0d5e6d65](https://github.com/ovn-org/ovn/commit/0d5e6d65db19845aede9198d8e164d934a5f189e) treewide: Fix small memory leaks reported by static analysis
+- [1a70f3f1](https://github.com/ovn-org/ovn/commit/1a70f3f171c032c2329bb66f2e62d233ce19a494) Documentation: Add note about pinning the container after release
+- [639aff08](https://github.com/ovn-org/ovn/commit/639aff0896527f9c48c56d6dfb3fdce84403b6dd) ci: Cover more container posibilities
+- [ca0f1775](https://github.com/ovn-org/ovn/commit/ca0f17758559ed836dfa0220e472ea99438cefb8) ci: Build container image before very job
+- [9c97cdcd](https://github.com/ovn-org/ovn/commit/9c97cdcd757ce356a85b3e6dde7eb19776fe4c38) ovs: Bump submodule to include IDL "spurious delete" fix.
+- [e9863e57](https://github.com/ovn-org/ovn/commit/e9863e57320d24f8fb0d02436834f795ba58ce48) Correct ethtype referencing incorrect values
+- [ed4e4a94](https://github.com/ovn-org/ovn/commit/ed4e4a94ba44f5d5be5148ee82f336cab3adc7ec) Revert "ovn: add geneve PMTUD support"
+- [20ea3b63](https://github.com/ovn-org/ovn/commit/20ea3b63fb3a2fce2c9e273bfbdcb4d8399b8091) northd: forward arp request to lrp snat on.
+- [8cabb443](https://github.com/ovn-org/ovn/commit/8cabb443ae88dded5cd1800bdcea5c5760954d25) northd: fix missing port up when deleting and adding back an lsp
+- [e54ec661](https://github.com/ovn-org/ovn/commit/e54ec661ef67cd93d1a72de907b37fab522bc2f9) ovn-macros: Make sure stopped daemons continue before the test ends.
+- [5141c9d4](https://github.com/ovn-org/ovn/commit/5141c9d4c7c861f6a65a711e59a4e64ae7d2fcdb) system-test: Fix tcpdump usage in LB template tests.
+- [49d33629](https://github.com/ovn-org/ovn/commit/49d33629595a9c7fc44d7ac86926c83e475b322d) tests: Move SCTP test from kernel only to general OVN system tests.
+- [d87ffbe4](https://github.com/ovn-org/ovn/commit/d87ffbe44d5b5c3f143c1e38e868f9db636b4565) tests: Remove 'protoinfo' from the conntrack entries for SCTP tests.
+- [44a40011](https://github.com/ovn-org/ovn/commit/44a40011f0b7f465c1eb60c9016bd56e09d7e538) northd: Skip transient IDL records.
+- [ba7a45bd](https://github.com/ovn-org/ovn/commit/ba7a45bde1de25868e0b16d8e58e6d523e2034ab) system-tests: Consolidate wait condition in CoPP test
+- [4ef375ed](https://github.com/ovn-org/ovn/commit/4ef375edc8bee094f24b9e649dc01ce3edd2034b) pinctrl: Fix up comments about sending RST packets for healthcheck.
+- [e42ca82f](https://github.com/ovn-org/ovn/commit/e42ca82fb92cd69bbfd4da72b3c22bc57fc1ecd0) ovn: add geneve PMTUD support
+- [b7889118](https://github.com/ovn-org/ovn/commit/b788911812171ee5d9c51806b1e287be910164c9) fmt_pkt: make sure scapy-server is started once
+- [820e1175](https://github.com/ovn-org/ovn/commit/820e11754bff7b7029abf8bd8f166c169bdd8d04) fmt_pkt: improve scapy-server logging
+- [2d710c3b](https://github.com/ovn-org/ovn/commit/2d710c3b1d9444a49f80db6058462e7d33253644) fmt_pkt: use -S check to wait for scapy sock file
+- [fc311bb6](https://github.com/ovn-org/ovn/commit/fc311bb6d6108d49b356d9c785f6d47e7dc8faff) fmt_pkt: don't subshell when calling ovs-appctl
+- [acc63727](https://github.com/ovn-org/ovn/commit/acc63727d14ff7e9f447ed90115f74235f968499) controller: fix group_table and meter_table allocation
+- [8a000cc8](https://github.com/ovn-org/ovn/commit/8a000cc863773030828a4cda2167840f08c4a65c) Prepare for 23.09.2.


### PR DESCRIPTION
This apparently is also marking 22.12 as unsupported, since this was not done back in December.