### PR TITLE
Fix broken links.

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -8,7 +8,7 @@ metaDataFormat = "yaml"
 defaultContentLanguageInSubdir= true
 
 [params]
-  editURL = "https://github.com/ovn-org/website/edit/master/src/content/"
+  editURL = "https://github.com/ovn-org/ovn-website/edit/main/src/content/"
   description = "Documentation website for the OVN project"
   author = "The OVN community"
   showVisitedLinks = true

--- a/src/content/contributing/website/_index.en.md
+++ b/src/content/contributing/website/_index.en.md
@@ -8,7 +8,7 @@ The OVN documentation website is based on hugo, grav, and the
 hugo-learn-theme and written in markdown format.
 
 If you want to contribute I recommend reading the
-[hugo-learn-theme documentation](https://themes.gohugo.io//theme/hugo-theme-learn/en/cont/pages/)
+[hugo-learn-theme documentation](https://themes.gohugo.io/themes/hugo-theme-learn/)
 
 You can always click the "Edit this page link" at the top right of each page, but
 if you want to test your changes locally before submitting you can:


### PR DESCRIPTION
Hi @putnopvut , I found two more broken links.

1) On the page https://www.ovn.org/en/contributing/, the "Edit this page" link was broken.

2) In the Readme, the "hugo-learn-theme documentation" link was also broken.

