### PR TITLE
Add generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 output/**
 hugo
 .hugo
+src/.hugo_build.lock
+src/public/**


### PR DESCRIPTION
Hi @numansiddique !
I found that some generated files are not in the .gitignore.

There are 3 my pull requests for review: this, https://github.com/ovn-org/ovn-website/pull/90 , https://github.com/ovn-org/ovn-website/pull/81

![изображение](https://github.com/ovn-org/ovn-website/assets/4289847/e99a6151-f6fa-44d0-b518-08e4e7af300d)
