### PR TITLE
ci: Make sure that we push all documentation changes

### DIFF
--- a/.github/workflows/dist-docs.yml
+++ b/.github/workflows/dist-docs.yml
@@ -117,3 +117,18 @@ jobs:
       with:
         name: dist-docs-${{ join(matrix.*, '-') }}
         path: /tmp/dist-docs.tgz
+
+  push-changes:
+    if: github.repository_owner == 'ovn-org' && github.ref_name == 'main'
+    name: Push changes
+    runs-on: ubuntu-latest
+    needs: [build-linux]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: checkout ovn-website
+        uses: actions/checkout@v4
+
+      - name: Trigger publish
+        run: gh workflow run publish.yml --ref main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: publish-push
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Unfortunately the automatic job trigger doesn't work when the GITHUB_TOKEN is used [0]. Add action that will trigger the publish action via gh cli tool.

[0] https://github.com/orgs/community/discussions/25702
Signed-off-by: Ales Musil <amusil@redhat.com>