### PR TITLE
hugo: Switch multilingual detection method.

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Make the static files
       run: make static
   
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: static-website 
         path: output

--- a/src/themes/hugo-theme-learn/layouts/partials/menu.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/menu.html
@@ -39,11 +39,11 @@
       </section>
     {{end}}
 
-    {{ if or .Site.IsMultiLingual $showvisitedlinks }}
+    {{ if or hugo.IsMultilingual $showvisitedlinks }}
     <section id="prefooter">
       <hr/>
       <ul>
-      {{ if and .Site.IsMultiLingual (not .Site.Params.DisableLanguageSwitchingButton)}}
+      {{ if and hugo.IsMultilingual (not .Site.Params.DisableLanguageSwitchingButton)}}
         <li>
           <a class="padding">
             <i class="fas fa-language fa-fw"></i>

--- a/src/themes/hugo-theme-learn/layouts/partials/search.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/search.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="{{"js/lunr.min.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
 <script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
 <script type="text/javascript">
-    {{ if .Site.IsMultiLingual }}
+    {{ if hugo.IsMultilingual }}
         var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
     {{ else }}
         var baseurl = "{{.Site.BaseURL}}";


### PR DESCRIPTION
".Site.IsMultiLingual" is deprecated. This commit changes to using "hugo.IsMultilingual" instead.